### PR TITLE
chore: update image style for dark mode

### DIFF
--- a/assets/_main.scss
+++ b/assets/_main.scss
@@ -390,3 +390,35 @@ aside nav,
   border-radius: .25rem;
   cursor: pointer;
 }
+
+
+img{
+  filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.6));
+}
+
+
+.book-brand {
+  position: relative;
+  display: inline-block;
+}
+
+.book-brand::before {
+  content: '';
+  position: absolute;
+  top: -5px;
+  left: -0px;
+  right: -5px;
+  bottom: -5px;
+  background: rgba(255, 255, 255, 0.4);
+  filter: blur(8px);
+  z-index: -1;
+  border-radius: 30%; /* Optional, for rounded glow */
+}
+
+.img-link a img{
+  background: #ffffff !important;
+}
+
+.book-footer{
+  clear: both;
+}


### PR DESCRIPTION
This pull request includes several changes to the `assets/_main.scss` file, focusing on enhancing the visual design of images and book branding elements.

Visual design enhancements:

* Added a drop-shadow filter to `img` elements to create a glowing effect.
* Introduced the `.book-brand` class with relative positioning and inline-block display, along with a `::before` pseudo-element to add a blurred background glow.
* Modified `.img-link a img` to ensure images have a white background.
* Added a `.book-footer` class to clear floats and ensure proper layout.