### PR TITLE
chore: for full version show

### DIFF
--- a/layouts/partials/docs/menu-versions.html
+++ b/layouts/partials/docs/menu-versions.html
@@ -13,7 +13,7 @@
   {{ else }}
   {{ $shortVer := split $version "." }}
   {{ if ge (len $shortVer) 3 }}
-  <option value="{{$version}}">{{ index $shortVer 0 }}.{{ index $shortVer 1 }}.x</option>
+  <option value="{{$version}}">{{ index $shortVer 0 }}.{{ index $shortVer 1 }}.{{ index $shortVer 2 }}</option>
   {{ else }}
   {{ if eq $i 1 }}
   <option value="{{$version}}">{{ $version }} </option>


### PR DESCRIPTION
This pull request includes a small change to the `layouts/partials/docs/menu-versions.html` file. The change ensures that the full version number, including the patch version, is displayed in the dropdown menu for documentation versions.

* [`layouts/partials/docs/menu-versions.html`](diffhunk://#diff-1102d7c6a5038c8736692d150ab3202002799f897e4c9c6e43c7a08baaaa2157L16-R16): Modified the version display format to include the patch version instead of using 'x' for the patch version.