### PR TITLE
chore: add json layouts

### DIFF
--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -1,0 +1,5 @@
+{{- $index := slice -}}
+{{- range where .Site.RegularPages.ByDate.Reverse "Type" "not in" (slice "page" "json") -}}
+    {{- $index = $index | append (dict "title" (.Title | plainify) "url" .Permalink "tags" .Params.tags "category" .Params.category "subcategory" .Params.subcategory "summary" (.Params.Summary | markdownify | plainify) "content" (.Content | markdownify | plainify)) -}}
+{{- end -}}
+{{- $index | jsonify -}}


### PR DESCRIPTION
This pull request adds a new feature to the `layouts/_default/index.json` file to generate a JSON index of regular pages on the site. The most important changes include creating a slice to hold the index, iterating over the site's regular pages in reverse order by date, and appending relevant page details to the index.

Improvements to JSON index generation:

* [`layouts/_default/index.json`](diffhunk://#diff-d920055ebff54fd433cd8d03e902a662bd6f6462c2dc7046a0061dd2e50119c9R1-R5): Created a slice to store the index and iterated over regular pages in reverse order by date, excluding pages of types "page" and "json". Appended page details including title, URL, tags, category, subcategory, summary, and content to the index, and converted the index to JSON format.