### PR TITLE
chore: update youtube shortcodes

### DIFF
--- a/layouts/shortcodes/youtube.html
+++ b/layouts/shortcodes/youtube.html
@@ -1,7 +1,52 @@
-<div class="embed video-player">
-    <iframe class="youtube-player" type="text/html"
-            width="640" height="385"
-            src="https://www.youtube.com/embed/09jf3ow9jfw"
-            allowfullscreen frameborder="0">
+{{/* 
+    Custom responsive YouTube shortcode (supports parameters + aspect ratio + lazy loading), compatible with Hugo v0.12~v0.124
+    Usage: {{< youtube VIDEO_ID start=30 autoplay=true controls=false loop=true mute=true ratio=4:3 >}}
+*/}}
+
+{{ $id := .Get 0 }}
+
+{{/* Parse optional parameters */}}
+{{ $start    := .Get "start" | default "" }}
+{{ $end      := .Get "end" | default "" }}
+{{ $autoplay := .Get "autoplay" | default "false" }}
+{{ $controls := .Get "controls" | default "true" }}
+{{ $loop     := .Get "loop" | default "false" }}
+{{ $mute     := .Get "mute" | default "false" }}
+{{ $ratioStr := .Get "ratio" | default "16:9" }}
+
+{{/* Calculate padding-bottom based on aspect ratio */}}
+{{ $ratioParts := split $ratioStr ":" }}
+{{ $padding := "56.25%" }} {{/* Default 16:9 */}}
+{{ if eq (len $ratioParts) 2 }}
+    {{ $w := (float (index $ratioParts 0)) }}
+    {{ $h := (float (index $ratioParts 1)) }}
+    {{ if and (gt $w 0) (gt $h 0) }}
+        {{ $padding = printf "%.6f%%" (mul (div $h $w) 100.0) }}
+    {{ end }}
+{{ end }}
+
+{{/* Build playback parameters */}}
+{{ $params := slice }}
+{{ if $start }}{{ $params = $params | append (printf "start=%s" $start) }}{{ end }}
+{{ if $end }}{{ $params = $params | append (printf "end=%s" $end) }}{{ end }}
+{{ if eq (lower $autoplay) "true" }}{{ $params = $params | append "autoplay=1" }}{{ end }}
+{{ if eq (lower $controls) "false" }}{{ $params = $params | append "controls=0" }}{{ end }}
+{{ if eq (lower $loop) "true" }}{{ $params = $params | append (printf "loop=1&playlist=%s" $id) }}{{ end }}
+{{ if eq (lower $mute) "true" }}{{ $params = $params | append "mute=1" }}{{ end }}
+
+{{ $query := "" }}
+{{ if gt (len $params) 0 }}
+    {{ $query = printf "?%s" (delimit $params "&") }}
+{{ end }}
+
+<div style="position: relative; padding-bottom: {{ $padding }}; height: 0; overflow: hidden; max-width: 100%;">
+    <iframe 
+        src="https://www.youtube.com/embed/{{ $id }}{{ $query }}"
+        title="YouTube video player"
+        loading="lazy"
+        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen>
     </iframe>
 </div>


### PR DESCRIPTION
Custom responsive YouTube shortcode (supports parameters + aspect ratio + lazy loading), compatible with Hugo v0.12~v0.124

Usage: {{< youtube VIDEO_ID start=30 autoplay=true controls=false loop=true mute=true ratio=4:3 >}}